### PR TITLE
Revert "Bump puma from 5.3.1 to 5.5.1"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -264,7 +264,7 @@ GEM
       activerecord (>= 5.2)
       activesupport (>= 5.2)
     public_suffix (4.0.6)
-    puma (5.5.1)
+    puma (5.3.1)
       nio4r (~> 2.0)
     racc (1.5.2)
     rack (2.2.3)


### PR DESCRIPTION
Reverts skwirl-io/market_back#18
Serverless gems isn't ready yet.